### PR TITLE
feat(server): added hosted frontend ip address to server

### DIFF
--- a/server/django_server/django_server/settings.py
+++ b/server/django_server/django_server/settings.py
@@ -133,5 +133,7 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 CORS_ALLOW_ALL_ORIGINS = False 
 
 CORS_ALLOWED_ORIGINS = [
-    'http://localhost:5173',  
+    'http://localhost:5173',
+    'https://playlist-generator-app-obi-sammys-projects.vercel.app/',
+    'https://playlist-generator-app.vercel.app/',
 ]


### PR DESCRIPTION
# Description
I added the hosted frontend ip address to the `CORS_ALLOWED_ORIGINS` to give it access to the hosted server.

Fixes: #8 

## Type of Change

- [ ] Bug fix
- [ ] Test update
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update